### PR TITLE
Bugfix/1 fix cli connection

### DIFF
--- a/Export/Export.ps1
+++ b/Export/Export.ps1
@@ -7,10 +7,13 @@ Import-Module .\src\DeleteItems\deleteItems.psm1
 #Saving credentials
 if(-not [System.IO.File]::Exists(".\Bitwarden.cred")){
     & $LibBitwardencli logout
+	clear
     & $LibBitwardencli login --apikey
 	& $LibBitwardencli lock
+	clear
 
     $Bitwarden_password = Read-Host -Prompt 'Please enter your master password'
+	clear
     $Bitwarden_password_SecureString = ConvertTo-SecureString $Bitwarden_password -AsPlainText -Force
     $Bitwarden = New-Object System.Management.Automation.PSCredential (' ', $Bitwarden_password_SecureString)
     $Bitwarden | Export-CliXml -Path ".\Bitwarden.cred"


### PR DESCRIPTION
Fix for #1 where we needed a new workflow for the authentication process.

We are now asking for OAuth 2.0 Client Credentials; `client_id` and `client_secret` for the first connection (the fact that we don't store these values makes BitwardenBackup more secure) and the `password` for the unlock.