### PR TITLE
Fix insecure use of SecureString

### DIFF
--- a/Export.ps1
+++ b/Export.ps1
@@ -32,9 +32,8 @@ function Export {
         & $LibBitwardencli lock
         clear
 
-        $Bitwarden_password = Read-Host -Prompt 'Please enter your master password'
+        $Bitwarden_password_SecureString = Read-Host -Prompt 'Please enter your master password' -AsSecureString
         clear
-        $Bitwarden_password_SecureString = ConvertTo-SecureString $Bitwarden_password -AsPlainText -Force
         $Bitwarden = New-Object System.Management.Automation.PSCredential (' ', $Bitwarden_password_SecureString)
         $Bitwarden | Export-CliXml -Path ".\\Export\\Bitwarden.cred"
     }


### PR DESCRIPTION
This closes #6.

Recommendation from [documentation](https://docs.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/rules/avoidusingconverttosecurestringwithplaintext?view=ps-modules) has been applied.